### PR TITLE
Improved the Candidate Name Search Ability

### DIFF
--- a/bin/field_extraction.py
+++ b/bin/field_extraction.py
@@ -6,6 +6,7 @@ from bin import lib
 
 EMAIL_REGEX = r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}"
 PHONE_REGEX = r"\(?(\d{3})?\)?[\s\.-]{0,2}?(\d{3})[\s\.-]{0,2}(\d{4})"
+NAME_REGEX = r'[a-z]+(\s+[a-z]+)?'
 
 
 def candidate_name_extractor(input_string, nlp):

--- a/bin/main.py
+++ b/bin/main.py
@@ -80,6 +80,11 @@ def transform(observations, nlp):
     # Extract candidate name
     observations['candidate_name'] = observations['text'].apply(lambda x:
                                                                 field_extraction.candidate_name_extractor(x, nlp))
+    
+    if observations['candidate_name'] = "NOT FOUND":
+        match = re.search(field_extraction.NAME_REGEX, observations['text'], re.IGNORECASE)
+        observations['candidate_name'] = match[0]
+        
 
     # Extract contact fields
     observations['email'] = observations['text'].apply(lambda x: lib.term_match(x, field_extraction.EMAIL_REGEX))

--- a/bin/main.py
+++ b/bin/main.py
@@ -81,7 +81,7 @@ def transform(observations, nlp):
     observations['candidate_name'] = observations['text'].apply(lambda x:
                                                                 field_extraction.candidate_name_extractor(x, nlp))
     
-    if observations['candidate_name'] = "NOT FOUND":
+    if observations['candidate_name'] == "NOT FOUND":
         match = re.search(field_extraction.NAME_REGEX, observations['text'], re.IGNORECASE)
         observations['candidate_name'] = match[0]
         


### PR DESCRIPTION
Spacy has some issues recognizing names. In cases where no name is found. We use regex to extract the first two words in the resume. The common resume format is the name first. 